### PR TITLE
revert require ssl

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -59,7 +59,7 @@ resource "google_sql_database_instance" "main" {
     user_labels       = var.md_metadata.default_tags
 
     ip_configuration {
-      require_ssl     = true
+      require_ssl     = false
       ipv4_enabled    = false
       private_network = local.network_id
     }


### PR DESCRIPTION
I enabled this as part of Bridgecrew but it forces use to create and expose client certificates. We could add those to the artifact but since this is a private instance, we don't need that extra layer. Inside GCP the Cloud SQL Auth proxy is used to create and manage certs so the traffic is encrypted without us shipping certs. I tested this from Cloud Run and `true` still forces certs even though the auth proxy is in use. 