### PR TITLE
Update tier selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ Form input parameters for configuring a bundle for deployment.
 - **`instance_configuration`** *(object)*: Instance type, disk size, configure properties for your primary instance.
   - **`disk_size`** *(integer)*: The size of the primary database instance in GB. Minimum: `20`. Maximum: `3054`.
   - **`disk_type`** *(string)*: Solid State has better performance for mixtures of reads and writes. Use Hard Disks for continuous read workloads or for cheaper storage. Must be one of: `['Solid State', 'Hard Disk']`. Default: `Solid State`.
-  - **`tier`** *(string)*: The type of compute used for the master instance. Must be one of: `['db-f1-micro', 'db-g1-small', 'db-n1-standard-1', 'db-n1-standard-2', 'db-n1-standard-4', 'db-n1-standard-8', 'db-n1-standard-16', 'db-n1-standard-32', 'db-n1-standard-64', 'db-n1-standard-96', 'db-n1-highmem-2', 'db-n1-highmem-4', 'db-n1-highmem-8', 'db-n1-highmem-16', 'db-n1-highmem-32', 'db-n1-highmem-64', 'db-n1-highmem-96']`.
+  - **`tier`** *(string)*: The type of compute used for the database instance.
+    - **One of**
+      - F1 Micro
+      - G1 Small
+      - Custom
 - **`transaction_log_retention_days`** *(integer)*: The number of days to keep the transaction logs before deleting them. Minimum: `1`. Maximum: `7`. Default: `5`.
 - **`username`** *(string)*: Primary DB username. Default: `root`.
 ## Examples
@@ -80,8 +84,10 @@ Form input parameters for configuring a bundle for deployment.
       "deletion_protection": true,
       "engine_version": "14.x",
       "instance_configuration": {
+          "cores": 10,
           "disk_size": 1000,
-          "tier": "db-n1-standard-32"
+          "memory": 19968,
+          "tier": "CUSTOM"
       }
   }
   ```
@@ -96,8 +102,10 @@ Form input parameters for configuring a bundle for deployment.
       "deletion_protection": true,
       "engine_version": "14.x",
       "instance_configuration": {
+          "cores": 1,
           "disk_size": 200,
-          "tier": "db-n1-standard-8"
+          "memory": 3840,
+          "tier": "CUSTOM"
       }
   }
   ```
@@ -203,11 +211,6 @@ Connections from other bundles that this bundle depends on.
         "us-west2"
         ```
 
-      - **`resource`** *(string)*
-      - **`service`** *(string)*
-      - **`zone`** *(string)*: GCP Zone.
-
-        Examples:
 - **`subnetwork`** *(object)*: A region-bound network for deploying GCP resources. Cannot contain additional properties.
   - **`data`** *(object)*
     - **`infrastructure`** *(object)*
@@ -276,6 +279,33 @@ Connections from other bundles that this bundle depends on.
         "projects/my-project/locations/us-west2/clusters/my-gke-cluster"
         ```
 
+      - **`vpc_access_connector`** *(string)*: GCP Resource Name (GRN).
+
+        Examples:
+        ```json
+        "projects/my-project/global/networks/my-global-network"
+        ```
+
+        ```json
+        "projects/my-project/regions/us-west2/subnetworks/my-subnetwork"
+        ```
+
+        ```json
+        "projects/my-project/topics/my-pubsub-topic"
+        ```
+
+        ```json
+        "projects/my-project/subscriptions/my-pubsub-subscription"
+        ```
+
+        ```json
+        "projects/my-project/locations/us-west2/instances/my-redis-instance"
+        ```
+
+        ```json
+        "projects/my-project/locations/us-west2/clusters/my-gke-cluster"
+        ```
+
   - **`specs`** *(object)*
     - **`gcp`** *(object)*: .
       - **`project`** *(string)*
@@ -286,11 +316,6 @@ Connections from other bundles that this bundle depends on.
         "us-west2"
         ```
 
-      - **`resource`** *(string)*
-      - **`service`** *(string)*
-      - **`zone`** *(string)*: GCP Zone.
-
-        Examples:
 <!-- CONNECTIONS:END -->
 
 </details>
@@ -364,6 +389,18 @@ Resources created by this bundle that can be connected to other bundles.
                 ```json
                 "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
                 ```
+
+          - **`identity`** *(object)*: For instances where IAM policies must be attached to a role attached to an AWS resource, for instance AWS Eventbridge to Firehose, this attribute should be used to allow the downstream to attach it's policies (Firehose) directly to the IAM role created by the upstream (Eventbridge). It is important to remember that connections in massdriver are one way, this scheme perserves the dependency relationship while allowing bundles to control the lifecycles of resources under it's management. Cannot contain additional properties.
+            - **`role_arn`** *(string)*: ARN for this resources IAM Role.
+
+              Examples:
+              ```json
+              "arn:aws:rds::ACCOUNT_NUMBER:db/prod"
+              ```
+
+              ```json
+              "arn:aws:ec2::ACCOUNT_NUMBER:vpc/vpc-foo"
+              ```
 
           - **`network`** *(object)*: AWS security group rules to inform downstream services of ports to open for communication. Cannot contain additional properties.
             - **`^[a-z-]+$`** *(object)*

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -3,18 +3,16 @@ name: gcp-cloud-sql-postgres
 description: "Fully managed PostgreSQL relational database service offering high availability, encryption, backups and zero-downtime capacity increases."
 source_url: github.com/massdriver-cloud/gcp-cloud-sql-postgres
 access: public
-type: bundle
-
-steps:
-  - path: src
-    provisioner: terraform
+type: infrastructure
 
 params:
   examples:
     - __name: Production
       engine_version: "14.x"
       instance_configuration:
-        tier: "db-n1-standard-32"
+        tier: "CUSTOM"
+        cores: 10
+        memory: 19968
         disk_size: 1000
       database_configuration:
         retained_backup_count: 7
@@ -23,7 +21,9 @@ params:
     - __name: Staging
       engine_version: "14.x"
       instance_configuration:
-        tier: "db-n1-standard-8"
+        tier: "CUSTOM"
+        cores: 1
+        memory: 3840
         disk_size: 200
       database_configuration:
         retained_backup_count: 7
@@ -40,6 +40,7 @@ params:
   required:
     - engine_version
     - username
+    - instance_configuration
   properties:
     engine_version:
       type: string
@@ -86,25 +87,48 @@ params:
         tier:
           type: string
           title: Instance Type
-          description: The type of compute used for the master instance.
-          enum:
-            - db-f1-micro
-            - db-g1-small
-            - db-n1-standard-1
-            - db-n1-standard-2
-            - db-n1-standard-4
-            - db-n1-standard-8
-            - db-n1-standard-16
-            - db-n1-standard-32
-            - db-n1-standard-64
-            - db-n1-standard-96
-            - db-n1-highmem-2
-            - db-n1-highmem-4
-            - db-n1-highmem-8
-            - db-n1-highmem-16
-            - db-n1-highmem-32
-            - db-n1-highmem-64
-            - db-n1-highmem-96
+          description: The type of compute used for the database instance.
+          oneOf:
+            - title: F1 Micro
+              const: db-f1-micro
+            - title: G1 Small
+              const: db-g1-small
+            - title: Custom
+              const: CUSTOM
+      dependencies:
+        tier:
+          oneOf:
+            - properties:
+                # TODO: validate core + memory combination
+                  #   min / max are valid first, then...
+                  #   memory_core_ratio = memory / cores
+                  #   900MB <= memory_core_ratio <= 6500MB && (cores % 2 == 0 || cores == 1) && memory % 256 == 0
+                tier:
+                  const: CUSTOM
+                cores:
+                  type: integer
+                  title: Cores
+                  description: The number of cores to use for the database instance. A multiple of 2, at most 96.
+                  minimum: 2
+                  maximum: 96
+                  multipleOf: 2
+                memory:
+                  type: integer
+                  title: Memory
+                  description: The amount of memory to use for the database instance. A multiple of 256 MB, at least 3840 MB. Per-core memory is allowed to range from 900 MB to 6.5 GB.
+                  # nearest multiple of 256 to 3750 MB is 3840
+                  minimum: 3840
+                  # 96 * 6500 MB is max cores times max memory per core
+                  maximum: 624000
+                  multipleOf: 256
+              required:
+                - cores
+                - memory
+            - properties:
+                tier:
+                  enum:
+                    - db-f1-micro
+                    - db-g1-small
     database_configuration:
       type: object
       title: Database Configuration
@@ -172,6 +196,9 @@ ui:
       - disk_size
       - disk_type
       - tier
+      - cores
+      - memory
+      - "*"
   database_configuration:
     ui:order:
       - high_availability_enabled

--- a/operator.mdx
+++ b/operator.mdx
@@ -7,7 +7,7 @@ Google Cloud SQL for PostgreSQL enables you to run a relational database with th
 ### Highly Scalable Data Store
 PostgreSQL is an open-source object-relational database-management system. With decades of development behind it and as one of the most popular solutions in its class, PostgreSQL excels as a backend database. It is versatile and adaptable.
 ### ACID Compliant
-PostgreSQL supports the rigorous requirements of financial institutions and others needing exceptional reliability. It supports atomicity, consistency, isolation, and durability (ACID) and online transaction processing (OLTP). 
+PostgreSQL supports the rigorous requirements of financial institutions and others needing exceptional reliability. It supports atomicity, consistency, isolation, and durability (ACID) and online transaction processing (OLTP).
 ### Spatial Data
 PostgreSQL is highly extensible. PostGIS, an extension for a geographical information system (GIS), provides hundreds of functions to process geometric data. In the decades since its initial release, PostGIS has become one of the de facto standards in the open-source GIS world.
 ### JSON Support
@@ -18,9 +18,9 @@ PostgreSQL also supports JSON data in either json or jsonb format. For querying 
 ### Development
 The development preset does not have deletion protection, allowing you to deprovision the database as needed. Since this preset is not intended for production, it will keep only one backup, and it comes with only a 20 GB disk and a shared-core CPU. This preset is suitable as a low-cost test and development instance only.
 ### Staging
-The staging preset provides high availability and the same backup and deletion protection as the production preset, with seven backups kept at all times. However, staging has only eight cores and a smaller 200 GB disk.
+The staging preset provides high availability and the same backup and deletion protection as the production preset, with seven backups kept at all times. However, staging has only 1 core and a smaller 200 GB disk.
 ### Production
-The production preset comes with thirty-two cores and a 1 TB disk. High availability, backups, and deletion protection (with seven backups) are enabled by default. For Postgres, we use the latest managed version of the 14.x series. This preset has sufficient resources to support a full production environment.
+The production preset comes with ten cores and a 1 TB disk. High availability, backups, and deletion protection (with seven backups) are enabled by default. For Postgres, we use the latest managed version of the 14.x series. This preset has sufficient resources to support a full production environment.
 
 ## Design
 
@@ -47,7 +47,7 @@ Replica configuration will be supported in a future release. Google recommends t
 ### Auto-generated password
 Upon database creation, we generate a random sixteen-character password.
 ### Private deployment
-This database will be available only in the gcp-global-network to which it is connected. 
+This database will be available only in the gcp-global-network to which it is connected.
 ### Data encrypted in transit
 By default, all data in transit will be encrypted with Secure Sockets Layer and Transport Layer Security (SSL/TLS).
 ### Data encrypted at rest

--- a/src/main.tf
+++ b/src/main.tf
@@ -5,7 +5,9 @@ locals {
   gcp_authentication = jsonencode(var.gcp_authentication.data)
   region             = var.subnetwork.specs.gcp.region
   # Cloud SQL expects the Global VPC GRN
-  network_id = var.subnetwork.data.infrastructure.gcp_global_network_grn
+  network_id     = var.subnetwork.data.infrastructure.gcp_global_network_grn
+  is_custom_tier = var.instance_configuration.tier == "CUSTOM"
+  db_tier        = local.is_custom_tier ? "db-custom-${var.instance_configuration.cores}-${var.instance_configuration.memory}" : var.instance_configuration.tier
 
   major_version_to_database_version = {
     "14.x"  = "POSTGRES_14"
@@ -52,7 +54,7 @@ resource "google_sql_database_instance" "main" {
   deletion_protection = var.deletion_protection
 
   settings {
-    tier = var.instance_configuration.tier
+    tier = local.db_tier
     # ALWAYS, NEVER, ON_DEMAND
     activation_policy = "ALWAYS"
     availability_type = "REGIONAL"


### PR DESCRIPTION
We aren't able to use the standard machine types for non-shared machines. A user has to specify cores and memory, this PR enables that.

+ [x] provisioned with dev (shared), staging (1 core), and prod (10 core) examples locally
+ [x] `bundle build` => bundle dev preview. Looked at params, tested that custom shows (and requires cores + memory)
+ [x] it's backwards-compat with existing valid configurations (shared cores)